### PR TITLE
Soften the warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,16 @@
+## :warning: Development Warning
+
+This project targets the development of the API client for the [DNSimple API v2](https://developer.dnsimple.com/v2/).
+
+This version is currently under development, therefore the methods and the implementation should he considered a work-in-progress. Changes in the method naming, method signatures, public or internal APIs may happen at any time.
+
+The code is tested with an automated test suite connected to a continuous integration tool, therefore you should not expect :bomb: bugs to be merged into master. Regardless, use this library at your own risk. :boom:
+
+
 # DNSimple C# Client
 
 A C# client for the [DNSimple API v2](https://developer.dnsimple.com/v2/).
 
-**IMPORTANT** This API is currently under development and should not be used (until you don't see this warning)!
-
-[DNSimple](https://dnsimple.com/) provides DNS hosting and domain registration that is simple and friendly.
-We provide a full API and an easy-to-use web interface so you can get your domain registered and set up with a minimal amount of effort.
 
 ## Installation
 


### PR DESCRIPTION
I've removed the "don't use" and applied the same warning from https://github.com/dnsimple/dnsimple-php to make it clear it's a development version, but usable.